### PR TITLE
Fix example update function

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,14 +32,14 @@ type Msg
     | NoOp
 
 
-update : Msg -> Model -> Model
+update : Msg -> Model -> (Model, Cmd Msg)
 update msg model =
     case msg of
         Increment ->
-            model + 1
+            (model + 1, Cmd.none)
 
         NoOp ->
-            model
+            (model, Cmd.none)
 
 
 {-| In this function we define `parse` in order to go from


### PR DESCRIPTION
I used the example code as a starting point for a new project. It broke because the update function was not returning the expected model/cmd tuple. Added Cmd.none and the example compiled as expected.
